### PR TITLE
torchvision roi align

### DIFF
--- a/modules/swapnet_modules.py
+++ b/modules/swapnet_modules.py
@@ -11,7 +11,7 @@ import torch
 from modules import pix2pix_modules, get_norm_layer
 
 sys.path.append("../lib")
-from model.roi_layers import ROIAlign
+from torchvision.ops import RoIAlign as ROIAlign
 from torch import nn
 
 from modules.layers import UNetDown, UNetUp, DualUNetUp, ResidualBlock


### PR DESCRIPTION
I was able to run the inference script, please perform other necessary tests.

You can rebase this pull request to a new branch which uses torch vision roi_align, for those who cant compile the native roi align. 

You can test it and later consider merging it into master because using roi align from other repository complicates things, when we already have torch vision installed.  And remove that roi compilation part from docker.